### PR TITLE
Add hot reloading for root reducer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1741,6 +1741,12 @@
         "@types/testing-library__dom": "*"
       }
     },
+    "@types/webpack-env": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.16.0.tgz",
+      "integrity": "sha512-Fx+NpfOO0CpeYX2g9bkvX8O5qh9wrU1sOF4g8sft4Mu7z+qfe387YlyY8w8daDyDsKY5vUxM0yxkAYnbkRbZEw==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "13.0.8",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/react": "^16.9.21",
     "@types/react-dom": "^16.9.5",
     "@types/react-redux": "^7.1.7",
+    "@types/webpack-env": "^1.16.0",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
     "eslint": "^6.7.2",

--- a/template.json
+++ b/template.json
@@ -10,6 +10,7 @@
       "@types/react-dom": "^16.9.0",
       "@types/react-redux": "^7.1.7",
       "@types/jest": "^24.0.0",
+      "@types/webpack-env": "^1.16.0",
       "react-redux": "^7.2.0",
       "typescript": "~4.1.5"
     }

--- a/template/src/app/reducers.ts
+++ b/template/src/app/reducers.ts
@@ -1,0 +1,8 @@
+import { combineReducers } from '@reduxjs/toolkit';
+import counterReducer from '../features/counter/counterSlice';
+
+const rootReducer = combineReducers({
+  counter: counterReducer,
+});
+
+export default rootReducer;

--- a/template/src/app/store.ts
+++ b/template/src/app/store.ts
@@ -1,11 +1,13 @@
 import { configureStore, ThunkAction, Action } from '@reduxjs/toolkit';
-import counterReducer from '../features/counter/counterSlice';
+import rootReducer from './reducers';
 
 export const store = configureStore({
-  reducer: {
-    counter: counterReducer,
-  },
+  reducer: rootReducer,
 });
+
+if (process.env.NODE_ENV !== 'production' && module.hot) {
+  module.hot.accept('./reducers', () => store.replaceReducer(rootReducer));
+}
 
 export type AppDispatch = typeof store.dispatch;
 export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION
This Pull Request adds hot reloading for reducers during development so that the users don't need to reload the page each time after updating reducer logic.