### PR TITLE
Simplify the `useAppDispatch` definition

### DIFF
--- a/template/src/app/hooks.ts
+++ b/template/src/app/hooks.ts
@@ -2,5 +2,5 @@ import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import type { RootState, AppDispatch } from './store';
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
-export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppDispatch: () => AppDispatch = useDispatch;
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;


### PR DESCRIPTION
This PR is related to issue #69, and updates the definition of `useAppDispatch` as mentioned in this [tweet](https://twitter.com/acemarke/status/1536794905741246464?s=20&t=fhL5493a3GreMY1N5KVeQw) by Mark Erikson.